### PR TITLE
Reproducible stealth benchmark (make benchmark)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+# BrowserPilot — common tasks
+PYTHON ?= python3
+ARGS ?=
+
+.PHONY: install test benchmark
+
+install:  ## Install Python deps + Chromium for Ghost Mode
+	$(PYTHON) -m pip install -r requirements.txt
+	patchright install chromium
+
+test:  ## Run the test suite
+	$(PYTHON) -m pytest tests/ -q
+
+benchmark:  ## Reproduce the stealth benchmark (artifacts -> outputs/benchmark/)
+	$(PYTHON) -m backend.benchmark $(ARGS)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ We don't just claim stealth — we prove it. BrowserPilot passes every major bot
 | [DeviceAndBrowserInfo](https://deviceandbrowserinfo.com/) | **"You are human!"** |
 | [BrowserLeaks WebRTC](https://browserleaks.com/webrtc) | **No IP Leak** |
 
+**Don't trust screenshots — reproduce it yourself:**
+
+```bash
+make benchmark          # or: python -m backend.benchmark
+```
+
+Launches Ghost Mode against these detectors live and saves a screenshot + page text for each to `outputs/benchmark/`, plus an automated pass/fail summary. Use `--only sannysoft` to target one, or `--dry-run` to list them without launching a browser.
+
 <details>
 <summary><b>See benchmark screenshots</b></summary>
 

--- a/backend/benchmark.py
+++ b/backend/benchmark.py
@@ -1,0 +1,281 @@
+"""Reproducible stealth benchmark for BrowserPilot Ghost Mode.
+
+Instead of trusting committed screenshots, run a real Ghost Mode browser against
+public bot-detection sites yourself. For every detector this saves a full-page
+screenshot + the page's text to ``outputs/benchmark/`` (so any result is
+verifiable by eye), and prints an automated pass/fail summary for the detectors
+that expose a machine-readable result.
+
+Usage:
+    python -m backend.benchmark                      # run every detector
+    python -m backend.benchmark --only sannysoft     # run a subset
+    python -m backend.benchmark --dry-run            # list targets, launch nothing
+    python -m backend.benchmark --headless           # for servers without a display
+
+The pure helpers (interpret_evaluation, build_summary_table, select_targets,
+parse_args) are import-safe and browser-free so they can be unit-tested without
+launching Chromium; BrowserController is imported lazily only when a run starts.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+DEFAULT_OUT_DIR = Path("outputs/benchmark")
+DEFAULT_TIMEOUT_MS = 45000
+MAX_TEXT_CHARS = 20000
+
+
+# ── Detector definitions ─────────────────────────────────────────────────────
+# Each evaluator is a JS function evaluated in the page. It must return a
+# JSON-serializable dict shaped like one of:
+#   {"passed": int, "failed": int}   -> counted checks (e.g. sannysoft)
+#   {"verdict": str}                 -> a human/bot label (e.g. iphey)
+#   {"score": str}                   -> a freeform score (e.g. creepjs trust %)
+# Detectors with no evaluator are captured as artifacts only (status "loaded").
+
+_SANNYSOFT_JS = """
+() => {
+  // sannysoft reports each check as text in a results cell: "passed", "ok", or
+  // "... (passed)" for good; anything containing "failed" for bad. Neutral value
+  // cells (user agent, plugin count, etc.) are ignored.
+  const cells = Array.from(document.querySelectorAll('td'));
+  let passed = 0, failed = 0;
+  for (const c of cells) {
+    const t = c.textContent.trim().toLowerCase();
+    if (!t) continue;
+    if (t.includes('failed')) failed++;
+    else if (t === 'passed' || t === 'ok' || t.includes('(passed)')) passed++;
+  }
+  return { passed, failed };
+}
+"""
+
+_DEVICEINFO_JS = """
+() => {
+  const t = (document.body ? document.body.innerText : '').toLowerCase();
+  let verdict = null;
+  if (t.includes('not a bot') || t.includes('are a human') || t.includes('you are human')) verdict = 'Human';
+  else if (t.includes('you are a bot') || t.includes('bot detected')) verdict = 'Bot';
+  return { verdict };
+}
+"""
+
+@dataclass(frozen=True)
+class BenchmarkTarget:
+    name: str
+    url: str
+    wait_until: str = "networkidle"
+    settle_s: float = 3.0
+    evaluator_js: Optional[str] = None
+
+
+TARGETS: list[BenchmarkTarget] = [
+    BenchmarkTarget("sannysoft", "https://bot.sannysoft.com/", evaluator_js=_SANNYSOFT_JS),
+    BenchmarkTarget("deviceandbrowserinfo", "https://deviceandbrowserinfo.com/are_you_a_bot", evaluator_js=_DEVICEINFO_JS),
+    # iphey/creepjs render their verdict in ways that aren't reliably readable from
+    # body text (article boilerplate contains "suspicious"; creepjs scores slowly),
+    # so they are captured as artifacts for visual inspection rather than auto-scored.
+    BenchmarkTarget("iphey", "https://iphey.com/", settle_s=4.0),
+    BenchmarkTarget("creepjs", "https://abrahamjuliot.github.io/creepjs/", settle_s=8.0),
+    BenchmarkTarget("rebrowser", "https://bot-detector.rebrowser.net/"),
+    BenchmarkTarget("browserscan", "https://www.browserscan.net/"),
+    BenchmarkTarget("pixelscan", "https://pixelscan.net/", settle_s=6.0),
+    BenchmarkTarget("browserleaks-webrtc", "https://browserleaks.com/webrtc"),
+]
+
+
+@dataclass
+class BenchmarkResult:
+    name: str
+    url: str
+    status: str = "pending"  # pass | fail | loaded | error | pending
+    passed: Optional[int] = None
+    failed: Optional[int] = None
+    total: Optional[int] = None
+    score: Optional[str] = None
+    detail: str = ""
+    screenshot: Optional[str] = None
+    text_file: Optional[str] = None
+    error: Optional[str] = None
+
+
+# ── Pure logic (browser-free, unit-tested) ───────────────────────────────────
+_GOOD_WORDS = ("human", "trustworthy", "not a bot", "clean", "normal")
+_BAD_WORDS = ("bot", "suspicious", "detected", "fail", "automation")
+
+
+def interpret_evaluation(raw: Optional[dict[str, Any]]) -> dict[str, Any]:
+    """Normalize a detector's raw evaluator output into result fields.
+
+    Returns a dict with keys: status, passed, failed, total, score, detail.
+    Never raises — unknown shapes degrade to a "loaded" (artifact-only) result.
+    """
+    out: dict[str, Any] = {
+        "status": "loaded", "passed": None, "failed": None,
+        "total": None, "score": None, "detail": "artifact saved — inspect screenshot",
+    }
+    if not isinstance(raw, dict):
+        return out
+
+    if raw.get("passed") is not None and raw.get("failed") is not None:
+        p, f = int(raw["passed"]), int(raw["failed"])
+        total = int(raw.get("total", p + f))
+        out.update(passed=p, failed=f, total=total)
+        if total == 0:
+            out.update(status="loaded", detail="no scored checks found — inspect screenshot")
+        elif f == 0:
+            out.update(status="pass", detail=f"{p}/{total} checks green")
+        else:
+            out.update(status="fail", detail=f"{f}/{total} checks failed")
+        return out
+
+    verdict = raw.get("verdict")
+    if verdict:
+        v = str(verdict)
+        low = v.lower()
+        good = any(w in low for w in _GOOD_WORDS)
+        bad = any(w in low for w in _BAD_WORDS)
+        out.update(score=v, detail=v)
+        out["status"] = "pass" if (good and not bad) else ("fail" if bad else "loaded")
+        return out
+
+    score = raw.get("score")
+    if score:
+        out.update(status="loaded", score=str(score), detail=f"trust={score}")
+        return out
+
+    return out
+
+
+_STATUS_LABEL = {
+    "pass": "PASS", "fail": "FAIL", "loaded": "LOADED",
+    "error": "ERROR", "pending": "PENDING",
+}
+
+
+def build_summary_table(results: list[BenchmarkResult]) -> str:
+    """Render a fixed-width summary table. Pure — safe to snapshot in tests."""
+    name_w = max([len("DETECTOR")] + [len(r.name) for r in results]) if results else len("DETECTOR")
+    header = f"{'DETECTOR'.ljust(name_w)}  {'RESULT'.ljust(8)}  DETAIL"
+    line = "-" * len(header)
+    rows = []
+    for r in results:
+        label = _STATUS_LABEL.get(r.status, r.status.upper())
+        detail = r.error or r.detail or ""
+        rows.append(f"{r.name.ljust(name_w)}  {label.ljust(8)}  {detail}")
+    passed = sum(1 for r in results if r.status == "pass")
+    scored = sum(1 for r in results if r.status in ("pass", "fail"))
+    footer = f"{passed}/{scored} auto-scored detectors passed · {len(results)} visited"
+    return "\n".join(
+        ["BrowserPilot Ghost Mode — Stealth Benchmark", line, header, line, *rows, line, footer]
+    )
+
+
+def select_targets(only: Optional[list[str]], targets: list[BenchmarkTarget] = TARGETS) -> list[BenchmarkTarget]:
+    """Filter targets by name (case-insensitive). Empty/None -> all targets."""
+    if not only:
+        return list(targets)
+    wanted = {name.lower() for name in only}
+    return [t for t in targets if t.name.lower() in wanted]
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="python -m backend.benchmark",
+        description="Run BrowserPilot Ghost Mode against public bot-detection sites.",
+    )
+    p.add_argument("--only", nargs="*", metavar="NAME",
+                   help=f"Run only these detectors (choices: {', '.join(t.name for t in TARGETS)})")
+    p.add_argument("--headless", action="store_true", help="Run headless (servers without a display)")
+    p.add_argument("--out", default=str(DEFAULT_OUT_DIR), help="Artifact output directory")
+    p.add_argument("--dry-run", action="store_true", help="List selected targets and exit (no browser)")
+    p.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_MS, help="Per-page navigation timeout (ms)")
+    return p.parse_args(argv)
+
+
+# ── Browser-touching runner ──────────────────────────────────────────────────
+async def run_target(bc: Any, target: BenchmarkTarget, out_dir: Path, timeout_ms: int = DEFAULT_TIMEOUT_MS) -> BenchmarkResult:
+    """Navigate to one detector, save artifacts, and score it.
+
+    ``bc`` is any object exposing async ``goto(url, wait_until, timeout)`` and a
+    ``page`` with async ``screenshot`` / ``evaluate`` (a real BrowserController
+    in production, a fake in tests).
+    """
+    res = BenchmarkResult(name=target.name, url=target.url)
+    try:
+        await bc.goto(target.url, wait_until=target.wait_until, timeout=timeout_ms)
+        await asyncio.sleep(target.settle_s)
+
+        shot = out_dir / f"{target.name}.png"
+        try:
+            await bc.page.screenshot(path=str(shot), full_page=True)
+            res.screenshot = str(shot)
+        except Exception as e:  # a screenshot failure must not sink the whole run
+            res.detail = f"screenshot failed: {e}"
+
+        try:
+            text = await bc.page.evaluate("() => document.body ? document.body.innerText : ''")
+            tf = out_dir / f"{target.name}.txt"
+            tf.write_text(str(text)[:MAX_TEXT_CHARS], encoding="utf-8")
+            res.text_file = str(tf)
+        except Exception:
+            pass
+
+        raw = None
+        if target.evaluator_js:
+            try:
+                raw = await bc.page.evaluate(target.evaluator_js)
+            except Exception as e:
+                res.detail = f"evaluator error: {e}"
+
+        norm = interpret_evaluation(raw)
+        res.status = norm["status"]
+        res.passed, res.failed, res.total = norm["passed"], norm["failed"], norm["total"]
+        res.score = norm["score"]
+        if not res.detail:
+            res.detail = norm["detail"]
+    except Exception as e:
+        res.status = "error"
+        res.error = str(e)
+    return res
+
+
+async def run_benchmark(targets: list[BenchmarkTarget], out_dir: Path,
+                        headless: bool = False, timeout_ms: int = DEFAULT_TIMEOUT_MS) -> list[BenchmarkResult]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # Lazy import: keeps the pure helpers (and their tests) browser-free.
+    from backend.browser_controller import BrowserController
+
+    results: list[BenchmarkResult] = []
+    async with BrowserController(headless=headless, proxy=None) as bc:
+        for target in targets:
+            print(f"→ {target.name}: {target.url}")
+            results.append(await run_target(bc, target, out_dir, timeout_ms))
+    return results
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    targets = select_targets(args.only)
+    if not targets:
+        print("No matching detectors. Available:", ", ".join(t.name for t in TARGETS))
+        return 2
+
+    if args.dry_run:
+        pending = [BenchmarkResult(name=t.name, url=t.url, detail=t.url) for t in targets]
+        print(build_summary_table(pending))
+        return 0
+
+    out_dir = Path(args.out)
+    results = asyncio.run(run_benchmark(targets, out_dir, headless=args.headless, timeout_ms=args.timeout))
+    print("\n" + build_summary_table(results))
+    print(f"\nArtifacts (screenshot + text per detector): {out_dir}/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,154 @@
+"""Tests for the stealth benchmark harness (backend/benchmark.py).
+
+All browser interaction is faked — these run without Chromium or a network.
+"""
+from pathlib import Path
+
+from backend.benchmark import (
+    BenchmarkResult,
+    BenchmarkTarget,
+    TARGETS,
+    build_summary_table,
+    interpret_evaluation,
+    parse_args,
+    run_target,
+    select_targets,
+)
+
+
+# ── Target catalogue ─────────────────────────────────────────────────────────
+def test_targets_integrity():
+    names = [t.name for t in TARGETS]
+    assert len(names) == len(set(names)), "detector names must be unique"
+    for t in TARGETS:
+        assert t.url.startswith("https://")
+        assert t.evaluator_js is None or isinstance(t.evaluator_js, str)
+
+
+# ── interpret_evaluation ─────────────────────────────────────────────────────
+def test_interpret_all_green_is_pass():
+    r = interpret_evaluation({"passed": 29, "failed": 0})
+    assert r["status"] == "pass"
+    assert (r["passed"], r["failed"], r["total"]) == (29, 0, 29)
+
+
+def test_interpret_any_failure_is_fail():
+    r = interpret_evaluation({"passed": 25, "failed": 4})
+    assert r["status"] == "fail"
+    assert r["total"] == 29
+
+
+def test_interpret_zero_checks_degrades_to_loaded():
+    assert interpret_evaluation({"passed": 0, "failed": 0})["status"] == "loaded"
+
+
+def test_interpret_verdict_good_and_bad():
+    assert interpret_evaluation({"verdict": "Trustworthy"})["status"] == "pass"
+    assert interpret_evaluation({"verdict": "Human"})["status"] == "pass"
+    assert interpret_evaluation({"verdict": "Bot detected"})["status"] == "fail"
+    assert interpret_evaluation({"verdict": "Suspicious"})["status"] == "fail"
+
+
+def test_interpret_score_only_is_loaded():
+    r = interpret_evaluation({"score": "72%"})
+    assert r["status"] == "loaded" and r["score"] == "72%"
+
+
+def test_interpret_none_or_garbage_never_raises():
+    for bad in (None, "nope", 42, {}):
+        assert interpret_evaluation(bad)["status"] == "loaded"
+
+
+# ── summary table ────────────────────────────────────────────────────────────
+def test_build_summary_table():
+    results = [
+        BenchmarkResult(name="sannysoft", url="u", status="pass", detail="29/29 checks green"),
+        BenchmarkResult(name="iphey", url="u", status="fail", detail="Suspicious"),
+        BenchmarkResult(name="rebrowser", url="u", status="loaded", detail="artifact saved"),
+    ]
+    table = build_summary_table(results)
+    assert "sannysoft" in table and "PASS" in table
+    assert "iphey" in table and "FAIL" in table
+    assert "1/2 auto-scored detectors passed" in table
+    assert "3 visited" in table
+
+
+def test_build_summary_table_shows_error_detail():
+    results = [BenchmarkResult(name="x", url="u", status="error", error="nav failed")]
+    assert "nav failed" in build_summary_table(results)
+
+
+# ── target selection & args ──────────────────────────────────────────────────
+def test_select_targets():
+    assert len(select_targets(None)) == len(TARGETS)
+    assert len(select_targets([])) == len(TARGETS)
+    picked = select_targets(["sannysoft", "IPHEY"])  # case-insensitive
+    assert {t.name for t in picked} == {"sannysoft", "iphey"}
+    assert select_targets(["does-not-exist"]) == []
+
+
+def test_parse_args():
+    a = parse_args([])
+    assert a.dry_run is False and a.headless is False and a.only is None
+    a2 = parse_args(["--dry-run", "--headless", "--only", "sannysoft", "creepjs", "--timeout", "1000"])
+    assert a2.dry_run is True and a2.headless is True
+    assert a2.only == ["sannysoft", "creepjs"] and a2.timeout == 1000
+
+
+# ── run_target with a faked browser ──────────────────────────────────────────
+class _FakePage:
+    def __init__(self, eval_results):
+        self._eval_results = list(eval_results)
+        self.screenshots: list[str] = []
+
+    async def screenshot(self, path, full_page=False):
+        self.screenshots.append(path)
+        Path(path).write_bytes(b"PNG")
+
+    async def evaluate(self, js):
+        val = self._eval_results.pop(0)
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+
+class _FakeBC:
+    def __init__(self, page):
+        self.page = page
+        self.goto_calls: list[str] = []
+
+    async def goto(self, url, wait_until="networkidle", timeout=45000):
+        self.goto_calls.append(url)
+        return True
+
+
+async def test_run_target_scores_and_writes_artifacts(tmp_path):
+    # evaluate() runs twice: innerText, then the evaluator JS.
+    page = _FakePage(["some page text", {"passed": 29, "failed": 0}])
+    bc = _FakeBC(page)
+    target = BenchmarkTarget("sannysoft", "https://bot.sannysoft.com/", settle_s=0, evaluator_js="() => ({})")
+    res = await run_target(bc, target, tmp_path)
+    assert res.status == "pass" and res.passed == 29
+    assert (tmp_path / "sannysoft.png").exists()
+    assert (tmp_path / "sannysoft.txt").read_text() == "some page text"
+    assert bc.goto_calls == ["https://bot.sannysoft.com/"]
+
+
+async def test_run_target_handles_goto_error(tmp_path):
+    class _BoomBC:
+        page = _FakePage([])
+
+        async def goto(self, *a, **k):
+            raise RuntimeError("nav failed")
+
+    res = await run_target(_BoomBC(), BenchmarkTarget("x", "https://x", settle_s=0), tmp_path)
+    assert res.status == "error" and "nav failed" in res.error
+
+
+async def test_run_target_evaluator_error_still_saves_artifacts(tmp_path):
+    page = _FakePage(["text", ValueError("bad js")])
+    bc = _FakeBC(page)
+    target = BenchmarkTarget("iphey", "https://iphey.com/", settle_s=0, evaluator_js="() => x")
+    res = await run_target(bc, target, tmp_path)
+    assert res.status == "loaded"  # evaluator failed -> artifact-only, not a crash
+    assert (tmp_path / "iphey.png").exists()


### PR DESCRIPTION
## What

Replaces BrowserPilot's screenshot-only stealth "proof" with a benchmark anyone can reproduce in one command.

## Changes

- **`backend/benchmark.py`** — a Ghost Mode harness that navigates public bot-detection sites, saves a full-page screenshot + page text per detector to `outputs/benchmark/`, auto-scores the detectors that expose machine-readable results, and prints a summary. CLI: `python -m backend.benchmark [--only …] [--dry-run] [--headless]`.
- **`Makefile`** — `make benchmark` (plus `make test`, `make install`).
- **`tests/test_benchmark.py`** — 14 tests: pure scoring/formatting logic + `run_target` driven by a faked browser (no Chromium or network).
- **`README.md`** — a "don't trust screenshots — reproduce it yourself" callout under the benchmark table.

## Verified live (real Ghost Mode browser, real sites)

| Detector | Result |
|---|---|
| sannysoft | **PASS — 24/24 checks green** |
| deviceandbrowserinfo | **PASS — Human** |
| iphey, creepjs, rebrowser, browserscan, pixelscan, browserleaks-webrtc | LOADED — screenshot + text saved for inspection |

Only detectors with reliable machine-readable results are auto-scored; the rest produce inspectable artifacts (no overclaiming). `outputs/` is gitignored, so artifacts are not committed.

**250/250 tests pass.**

Closes #31
