### PR TITLE
hotfix: pin Gemini to gemini-flash-latest (2.5-flash retired for new keys)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -7,7 +7,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # ── AI Model ──────────────────────────────────────────────────────────────────
-GEMINI_MODEL_NAME: str = os.getenv("GEMINI_MODEL_NAME", "gemini-2.5-flash")
+# Use the "-latest" alias, not a dated/versioned id: Google retires specific
+# versions ("no longer available to new users"), but the alias always resolves
+# to the current Flash model. Override with GEMINI_MODEL_NAME if you need a pin.
+GEMINI_MODEL_NAME: str = os.getenv("GEMINI_MODEL_NAME", "gemini-flash-latest")
 GOOGLE_API_KEY: str = os.getenv("GOOGLE_API_KEY", "")
 
 # ── User-Agent pool ──────────────────────────────────────────────────────────

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,8 +24,9 @@ def test_get_random_ua_uses_env_pool(monkeypatch):
 
 def test_gemini_model_name_default():
     cfg = reload_config()
-    # Default must be a stable GA model, not a dated preview that Google will retire.
-    assert cfg.GEMINI_MODEL_NAME == "gemini-2.5-flash"
+    # Default must be the "-latest" alias — Google retires versioned ids for new
+    # users, but the alias always resolves to the current Flash model.
+    assert cfg.GEMINI_MODEL_NAME == "gemini-flash-latest"
 
 
 def test_gemini_model_name_from_env(monkeypatch):


### PR DESCRIPTION
Live testing surfaced that `gemini-2.5-flash` (the Phase-0 pin) now returns 404 "no longer available to new users" — so **main is broken for every new user's Gemini key**. Switch the default to the `gemini-flash-latest` alias, which always resolves to the current Flash model and won't be deprecated. Verified live: `/scrape/structured` returns real structured rows with this model. Env-overridable via `GEMINI_MODEL_NAME`.